### PR TITLE
Update Streamlit app to automatically calculate advance amount and se…

### DIFF
--- a/feature/streamlit-ui/app.py
+++ b/feature/streamlit-ui/app.py
@@ -51,12 +51,11 @@ def mainInputs(
     st.session_state.variable_interest_rate = variable_interest_rate
     st.write("Note: The interest rate is variable and may change over time.")
 
-    advance_amount = st.number_input(
-        "Advance Amount (in Shillings)", min_value=0.0, step=100.0, format="%.2f"
-    )
+    # Calculate advance amount as 40% of gross pay and set duration to 1 month
+    advance_amount = gross_pay * 0.4
+    advance_duration = 1
+    st.write(f"Maximum Advance Amount Available: {advance_amount:.2f} Shillings")
     st.session_state.advance_amount = advance_amount
-
-    advance_duration = st.number_input("Advance Duration (Months)", min_value=1, step=1)
     st.session_state.advance_duration = advance_duration
 
     if st.button("Calculate"):


### PR DESCRIPTION
…t fixed duration
   Changes made:
   - Remove manual advance amount input
   - Calculate advance amount automatically as 40% of gross pay
   - Set fixed advance duration to 1 month
   - Display maximum advance amount available to user
   - Maintain existing loan calculation and analysis functionality